### PR TITLE
Bugfixes

### DIFF
--- a/bin/GetPerlModuleDepTreeFromCPAN.pl
+++ b/bin/GetPerlModuleDepTreeFromCPAN.pl
@@ -113,7 +113,7 @@ if ($output_format eq 'list') {
 		my $archive;
 		my $author;
 		my $version;
-		if ($distro =~ m|(.+)/(([^/]+)-(v?[0-9.]+).tar.gz)$|) {
+		if ($distro =~ m|(.+)/(([^/]+)-(v?[0-9.]+).t(ar.)?gz)$|) {
 			$author  = $1;
 			$archive = $2;
 			$version = $4;


### PR DESCRIPTION
* ```hpc-environment-sync.bash```: Added rsync of the Lmod cache when syncing only one or more modules.
* ```GetPerlModuleDepTreeFromCPAN.pl```: Parse more rare ```.tgz``` extensions in addition to the more common ```.tar.gz```.